### PR TITLE
fix "make install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,5 @@ install: all
 		sudo install -m 0755 $(TARGET_DIR)/$$app.$(OS).$(ARCH) $(INSTALL_PREFIX)/bin/$$app; done \
 
 deps:
-	go get -v ./...
+	go get -v -t ./...
 	mkdir -p $(TARGET_DIR)


### PR DESCRIPTION
Hi! Thanks for the cool package!

I wanted to compile package locally with `make install`, but tests didn't pass because package `github.com/stretchr/testify/assert` wasn't installed. I think that an additional flag to `go get` should be added.
https://golang.org/cmd/go/#hdr-Add_dependencies_to_current_module_and_install_them